### PR TITLE
Request to merge changes for Issue 7: Better css for the result page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 /openstudyroom/settings/base.py
 media
 [0-9]*
+/.idea

--- a/league/templates/league/results.html
+++ b/league/templates/league/results.html
@@ -11,6 +11,9 @@
         width:auto;
         margin-top:60px;
     }
+    .table-responsive{
+        overflow-x: visible;
+    }
     table#example th{
         text-align: center;
         min-width:20px;

--- a/league/templates/league/results.html
+++ b/league/templates/league/results.html
@@ -2,6 +2,34 @@
 {% load league_tags %}
 {% block title %}{{event}}- Results{% endblock %}
 {% block content %}
+<style>
+    table#example th{
+        text-align: center;
+        width:10px;
+    }
+    table#example th:nth-of-type(1){
+        text-align: left;
+        width:12em;
+    }
+    table#example th:nth-of-type(2){
+        text-align: left;
+        width:0em;
+    }
+    table#example th div{
+        transform: rotate(-60deg);
+        transform-origin: 0 0;
+        position: absolute;
+        margin-top: -10px;
+    }
+    thead.table-league-highlight{
+        height:20px;
+    }
+    iframe[name="wgo_iframe"]{
+        height:700px;
+        width: 700px;
+        border:none;
+    }
+</style>
 <nav class="navbar navbar-default">
 <ul class="nav navbar-nav navbar-left">
   <li><a href="{% url 'league:event' event.pk %}">Overview</a></li>
@@ -22,12 +50,14 @@
 
 <div class='table-responsive'>
   <table id='example' class='table table-bordered  table-hover table-condensed' >
-     <thead class='table-league-highlight' style='heigh:20px'
+     <thead class='table-league-highlight'>
        <tr>
-         <th style="width:12em;">player</th>
-         <th style="width:0em;"> score</th>
+         <th>player</th>
+         <th> score</th>
         {% for player in players %}
-       		<th style='text-align: center;width:10px;'> <div style ='transform: rotate(-60deg);transform-origin: 0 0;position: absolute;margin-top: -10px;'>{{ player.kgs_username }}</div></th>
+       		<th>
+                <div>{{ player.kgs_username }}</div>
+            </th>
         {% endfor %}
         </thead>
         <tbody>
@@ -54,6 +84,6 @@
         	</tbody>
         </table>
       </div>
-<iframe name="wgo_iframe" scrolling="no" style= "height:700px;width: 700px;border:none;"></iframe>
+<iframe name="wgo_iframe" scrolling="no"></iframe>
 
 {% endblock %}

--- a/league/templates/league/results.html
+++ b/league/templates/league/results.html
@@ -19,6 +19,13 @@
     table#example th:nth-of-type(2){
         text-align: left;
     }
+    tr.even-row,
+    td.even-column{
+        background-color:#f8f8f8;
+    }
+    td.table-league-highlight {
+        background-color: LightGray;
+    }
     .kgs_username{
         transform: rotate(-60deg);
         transform-origin: 0 0;
@@ -66,15 +73,15 @@
         </thead>
         <tbody>
         {% for player in players %}
-        <tr>
+        <tr class="{% cycle 'even-row' 'odd-row' %}">
             <td class='table-league-player'>{{forloop.counter}}. {{player.user | user_link}}</td>
             <td class='table-league-score-highlight'>{{player.score}}</td>
             {% for opponent in players %}
 
             {% if forloop.counter == forloop.parentloop.counter %}
-            <td class='table-league-highlight'>
+            <td class="table-league-highlight {% cycle 'even-column' 'odd-column' %}">
                 {% else %}
-            <td>
+            <td class="{% cycle 'even-column' 'odd-column' %}">
                 {% if opponent.kgs_username in player.get_results %}
 
                 {% html_one_result %}

--- a/league/templates/league/results.html
+++ b/league/templates/league/results.html
@@ -31,59 +31,59 @@
     }
 </style>
 <nav class="navbar navbar-default">
-<ul class="nav navbar-nav navbar-left">
-  <li><a href="{% url 'league:event' event.pk %}">Overview</a></li>
-  <li class = active ><a href="{% url 'league:results' event.pk %}">Results</a></li>
-  <li><a href="{% url 'league:players' event.pk %}">Players</a></li>
-  <li><a href="{% url 'league:games' event.pk %}">Games</a></li>
-</ul>
-<ul class="nav navbar-nav navbar-right" style="margin-right:5px;">
-  <li {%if not close %}class ="active"{%endif%}><a href="{% url 'league:event' %}">Current league</a></li>
-  <li><a href="{% url 'league:archives' %}">Archives</a></li>
-</ul>
+    <ul class="nav navbar-nav navbar-left">
+        <li><a href="{% url 'league:event' event.pk %}">Overview</a></li>
+        <li class = active ><a href="{% url 'league:results' event.pk %}">Results</a></li>
+        <li><a href="{% url 'league:players' event.pk %}">Players</a></li>
+        <li><a href="{% url 'league:games' event.pk %}">Games</a></li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right" style="margin-right:5px;">
+        <li {%if not close %}class ="active"{%endif%}><a href="{% url 'league:event' %}">Current league</a></li>
+        <li><a href="{% url 'league:archives' %}">Archives</a></li>
+    </ul>
 </nav>
 <ul class="nav nav-tabs">
-{% for div in event.get_divisions %}
-<li {% if div == division %}class='active'{%endif%} > {{div|division_link}}</li>
-{% endfor %}
+    {% for div in event.get_divisions %}
+    <li {% if div == division %}class='active'{%endif%} > {{div|division_link}}</li>
+    {% endfor %}
 </ul>
 
 <div class='table-responsive'>
-  <table id='example' class='table table-bordered  table-hover table-condensed' >
-     <thead class='table-league-highlight'>
-       <tr>
-         <th>player</th>
-         <th> score</th>
-        {% for player in players %}
-       		<th>
+    <table id='example' class='table table-bordered  table-hover table-condensed' >
+        <thead class='table-league-highlight'>
+        <tr>
+            <th>player</th>
+            <th> score</th>
+            {% for player in players %}
+            <th>
                 <div>{{ player.kgs_username }}</div>
             </th>
-        {% endfor %}
+            {% endfor %}
         </thead>
         <tbody>
-          {% for player in players %}
-        		<tr>
-              <td class='table-league-player'>{{forloop.counter}}. {{player.user | user_link}} </td>
-        		<td class='table-league-score-highlight'>{{player.score}} </td>
-        		{% for opponent in players %}
+        {% for player in players %}
+        <tr>
+            <td class='table-league-player'>{{forloop.counter}}. {{player.user | user_link}} </td>
+            <td class='table-league-score-highlight'>{{player.score}} </td>
+            {% for opponent in players %}
 
-        			{% if forloop.counter == forloop.parentloop.counter %}
-              <td style='text-align: center;' class='table-league-highlight'>
-        			{% else %}
-              <td style='text-align: center;'>
-              {% if opponent.kgs_username in player.get_results %}
+            {% if forloop.counter == forloop.parentloop.counter %}
+            <td style='text-align: center;' class='table-league-highlight'>
+                {% else %}
+            <td style='text-align: center;'>
+                {% if opponent.kgs_username in player.get_results %}
 
-              {% html_one_result %}
+                {% html_one_result %}
 
-              {% endif %}
-              </td>
-              {% endif %}
+                {% endif %}
+            </td>
+            {% endif %}
             {% endfor %}
-              </tr>
-            {% endfor %}
-        	</tbody>
-        </table>
-      </div>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
 <iframe name="wgo_iframe" scrolling="no"></iframe>
 
 {% endblock %}

--- a/league/templates/league/results.html
+++ b/league/templates/league/results.html
@@ -3,26 +3,30 @@
 {% block title %}{{event}}- Results{% endblock %}
 {% block content %}
 <style>
+    body .container{
+        width: auto;
+        margin: 0 20px;
+    }
+    table#example{
+        width:auto;
+        margin-top:60px;
+    }
     table#example th{
         text-align: center;
-        width:10px;
+        min-width:20px;
     }
-    table#example th:nth-of-type(1){
-        text-align: left;
-        width:12em;
-    }
+    table#example th:nth-of-type(1),
     table#example th:nth-of-type(2){
         text-align: left;
-        width:0em;
     }
-    table#example th div{
+    .kgs_username{
         transform: rotate(-60deg);
         transform-origin: 0 0;
         position: absolute;
         margin-top: -10px;
     }
-    thead.table-league-highlight{
-        height:20px;
+    .table-league-score-highlight{
+        text-align: center;
     }
     iframe[name="wgo_iframe"]{
         height:700px;
@@ -53,24 +57,24 @@
         <thead class='table-league-highlight'>
         <tr>
             <th>player</th>
-            <th> score</th>
+            <th>score</th>
             {% for player in players %}
             <th>
-                <div>{{ player.kgs_username }}</div>
+                <div class="kgs_username">{{ player.kgs_username }}</div>
             </th>
             {% endfor %}
         </thead>
         <tbody>
         {% for player in players %}
         <tr>
-            <td class='table-league-player'>{{forloop.counter}}. {{player.user | user_link}} </td>
-            <td class='table-league-score-highlight'>{{player.score}} </td>
+            <td class='table-league-player'>{{forloop.counter}}. {{player.user | user_link}}</td>
+            <td class='table-league-score-highlight'>{{player.score}}</td>
             {% for opponent in players %}
 
             {% if forloop.counter == forloop.parentloop.counter %}
-            <td style='text-align: center;' class='table-league-highlight'>
+            <td class='table-league-highlight'>
                 {% else %}
-            <td style='text-align: center;'>
+            <td>
                 {% if opponent.kgs_username in player.get_results %}
 
                 {% html_one_result %}

--- a/openstudyroom/static/css/openstudyroom.css
+++ b/openstudyroom/static/css/openstudyroom.css
@@ -8,9 +8,6 @@
 .table-league {
     background-color: WhiteSmoke;
 }
-.table-league-highlight {
-    background-color: LightGray;
-}
 .table-league-score-highlight {
     background-color: #d9edf7;
 }


### PR DESCRIPTION
I couldn't actually figure out how to include my own CSS file (I tried "load static" with no luck) so I simply included a "style" tag in the requested template. Typically this is a frontend faux-pas, though I figured it was an improvement over the inline styles. Hopefully someone can teach me how to include a stylesheet... o'_'o

Anyway, just some simple changes. It seems like you have a lot of data on the page, so I just allowed the table to scale with the data. Sometimes this means it goes off the screen. Naturally, you can restore a max-width to the table, but then the columns will be squished.

I wonder if there might be a larger refactor in here. Maybe there is a better way to see the data instead of one giant round-robin table? For instance, maybe standings per league - wins and losses. Then maybe if you click on a player, you can see their game history. Sort of like the player profile page on OGS. Anyway, just a thought. Hopefully this code helps.