### PR TITLE
Fix Travis fail

### DIFF
--- a/openstudyroom/widget.py
+++ b/openstudyroom/widget.py
@@ -14,7 +14,7 @@ class MarkdownTextareaWidget(Textarea):
             '//cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js'
         )
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         attrs = {} if attrs is None else attrs
         classes = attrs.get('classes', '')
         attrs['data-provide'] = "markdown"


### PR DESCRIPTION
Travis failed with 

```
************* Module openstudyroom.widget
W: 17, 4: Parameters differ from overridden 'render' method (arguments-differ)
```
There was a missing argument (renderer=None) that I added in the method header.