### PR TITLE
Clarify reverse search ability in players tables

### DIFF
--- a/league/templates/league/archives_players.html
+++ b/league/templates/league/archives_players.html
@@ -52,7 +52,11 @@
 
 <script type="text/javascript">
 $(document).ready(function() {
-$('#player-table').DataTable();
+$('#player-table').DataTable({
+    language: {
+        searchPlaceholder: "OSR/KGS/OGS username"
+    }
+});
 } );
 </script>
 {% endblock %}

--- a/league/templates/league/players.html
+++ b/league/templates/league/players.html
@@ -67,6 +67,9 @@
 <script type="text/javascript">
 $(document).ready(function() {
  $('#player-table').DataTable({
+    language: {
+        searchPlaceholder: "OSR/KGS/OGS username"
+    }
   //"dom":'<"col-md-2"lf>rt<"col-sm-5"i><"col-sm-5"p>'
 }//<"H"lr>ft<"F"ip>'
 );


### PR DESCRIPTION
I added the string "OSR/KGS/OGS username" as a placeholder in the search field for the two players tables.

Fixes #215