### PR TITLE
Perf archive

### DIFF
--- a/league/models.py
+++ b/league/models.py
@@ -603,6 +603,20 @@ class User(AbstractUser):
     def is_osr_admin(self):
         return self.groups.filter(name='OSR_admin').exists()
 
+    def get_packed_info(self):
+        players = self.leagueplayer_set.all()
+        info={}
+        info["nb_players"] = players.count()
+        info["nb_games"] = 0
+        info["nb_win"] = 0
+        info["nb_loss"] = 0
+        for player in players:
+            (nb_games, nb_win, nb_loss) = player.nb_games_win_loss()
+            info["nb_games"] += nb_games
+            info["nb_win"] += nb_win
+            info["nb_loss"] += nb_loss
+        return info
+
 
     def nb_games(self):
         players = self.leagueplayer_set.all()
@@ -1070,6 +1084,14 @@ class LeaguePlayer(models.Model):
             }
             resultsDict[opponent.pk].append(record)
         return resultsDict
+
+    def nb_games_win_loss(self):
+        user = self.user
+        event= self.event
+        games = event.sgf_set.filter(Q(black=user) | Q(white=user))
+        return (games.count(),
+            games.filter(winner=user).count(),
+            games.exclude(winner=user).count())
 
     def nb_win(self):
         user = self.user

--- a/league/models.py
+++ b/league/models.py
@@ -605,7 +605,7 @@ class User(AbstractUser):
 
     def get_packed_info(self):
         players = self.leagueplayer_set.all()
-        info={}
+        info = {}
         info["nb_players"] = players.count()
         info["nb_games"] = 0
         info["nb_win"] = 0
@@ -1087,7 +1087,7 @@ class LeaguePlayer(models.Model):
 
     def nb_games_win_loss(self):
         user = self.user
-        event= self.event
+        event = self.event
         games = event.sgf_set.filter(Q(black=user) | Q(white=user))
         return (games.count(),
             games.filter(winner=user).count(),

--- a/league/templates/league/archives_players.html
+++ b/league/templates/league/archives_players.html
@@ -32,13 +32,15 @@
     </thead>
     <tbody>
       {% for u in users %}
+      {% with info=u.get_packed_info %}
       <tr>
         <td>{{u | user_link}}</td>
-        <td>{{u.nb_players}}</td>
-        <td>{{u.n_win}}</td>
-        <td>{{u.n_loss}}</td>
-        <td>{{u.n_games}}</td>
+        <td>{{info.nb_players}}</td>
+        <td>{{info.nb_win}}</td>
+        <td>{{info.nb_loss}}</td>
+        <td>{{info.nb_games}}</td>
     </tr>
+     {% endwith %}
      {% endfor %}
    </tbody>
  </table>


### PR DESCRIPTION
Refactored the way we get info to display on players archive page.

- Only 1 call is made to `get_packed_info` instead of calling `nb_players`, `nb_win` and so on ==> only one database request to get `leagueplayer_set` instead of 4

- Create 1 function on `LeaguePlayer` to get games, wins and loss at the same time ==> create one queryset for all games and filter from it

Possible improvement : if draw or undefined is not allowed (meaning a game is either won or lost), we could gain some more time by computing `nb_loss` as `nb_games` - `nb_win`

I tested on the fixtures available on dev and all looked good.