### PR TITLE
Upgrade bootstrap3 9 → 11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-allauth==0.30.0
 django-annoying==0.10.3
 django-anymail==4.2
 django-appconf==1.0.2
-django-bootstrap3==9.0.0
+django-bootstrap3==11.0.0
 django-cogwheels==0.2
 django-colorful==1.3
 django-common-helpers==0.9.0


### PR DESCRIPTION
django-bootstrap3 11.0.0 fixes `PasswordInput`, which fixes styles on the account signup page:
https://github.com/dyve/django-bootstrap3/commit/8cb87ae50e38b4a3062b6abd1832bb14e47e08af

before:
![before](https://user-images.githubusercontent.com/90059/46931484-27234380-d000-11e8-9b1f-609163e769c2.png)

after:
![after](https://user-images.githubusercontent.com/90059/46931448-06f38480-d000-11e8-8067-71f43ac87ccd.png)
