### PR TITLE
Fix 501 when updating a calendar event

### DIFF
--- a/fullcalendar/urls.py
+++ b/fullcalendar/urls.py
@@ -8,7 +8,7 @@ app_name = 'fullcalendar'
 urlpatterns = [
     url(
         r'^update/(?P<pk>[0-9]+)/$',
-        views.PublicEventUpdate.as_view(),
+        views.PublicEventUpdate.as_view(success_url='/calendar/admin/event-list/'),
         name='update_cal_event'
     ),
     url(


### PR DESCRIPTION
Hitting `/calendar/update/{pk}/` results in a 501 with `No URL to redirect to. Either provide a url or define a get_absolute_url method on the Model`. This adds the missing `success_url`.

Fixes #301