### PR TITLE
Solve league sorting issue

### DIFF
--- a/league/models.py
+++ b/league/models.py
@@ -28,6 +28,7 @@ class LeagueEvent(models.Model):
     The Event name is unfortunate and should be removed mone day.
     """
 
+    # Orders ared defined in get_events
     EVENT_TYPE_CHOICES = (
         ('ladder', 'ladder'),
         ('league', 'league'),
@@ -229,7 +230,13 @@ class LeagueEvent(models.Model):
                 is_public=True,
                 community__isnull=True
             )
-        events = events.exclude(event_type='tournament').order_by('event_type')
+        events = events.exclude(event_type='tournament')
+        order = ['ladder', 'league', 'meijin', 'dan', 'ddk', 'tournament']
+        whens = []
+        for ind, v in enumerate(order):
+            whens.append(models.When(event_type=v, then=ind))
+        events = events.annotate(_sort_index=models.Case(*whens, output_field=models.IntegerField()))
+        events = events.order_by('_sort_index')
         return events
 
 


### PR DESCRIPTION
This should close #291 

In order to sort the events, we annotate a field in the query `_sort_index` that gets its value based on event_type's location in the order array. Then we sort by _sort_index.

For more reference: https://stackoverflow.com/questions/5966462/sort-queryset-by-values-in-list