### PR TITLE
Missing closing ">" on anchor tag for Facebook

### DIFF
--- a/home/templates/home/includes/socials_footer.html
+++ b/home/templates/home/includes/socials_footer.html
@@ -11,7 +11,7 @@
 <i class="fa fa-google-plus-square" aria-hidden="true"></i>
 </a>
 
-<a href="https://www.facebook.com/Openstudyroom/" data-toggle="tooltip" title="Facebook"
+<a href="https://www.facebook.com/Openstudyroom/" data-toggle="tooltip" title="Facebook">
 <i class="fa fa-facebook-official" aria-hidden="true"></i>
 </a>
 <a href="https://twitter.com/OpenStudyRoom" data-toggle="tooltip" title="Twitter" tabindex="-1">


### PR DESCRIPTION
This would cover errors 16-19 in the W3C link from #27. It's a small change, but hopefully I'll get some time to contribute more in the future!