### PR TITLE
bump python in travis 3.4 → 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - '3.4'
+  - '3.5'
   - 'nightly'
 
 sudo: false


### PR DESCRIPTION
we run 3.5.3 in production. this runs 3.5.6, which is close enough