### PR TITLE
Style changes to .wgo-player-menu to fix incorrect positioning

### DIFF
--- a/wgo/static/wgo/wgo.player.css
+++ b/wgo/static/wgo/wgo.player.css
@@ -594,8 +594,8 @@ a.wgo-move-link {
 	box-shadow: 0 0 20px 0 rgba(127,127,127,0.5);
 	font-weight: bold;
 	color: #292929;
-	left: 3%;
-	top: 13%;
+	left: 3% !important;
+	top: 13% !important;
 }
 
 .wgo-menu-item {

--- a/wgo/static/wgo/wgo.player.css
+++ b/wgo/static/wgo/wgo.player.css
@@ -594,6 +594,8 @@ a.wgo-move-link {
 	box-shadow: 0 0 20px 0 rgba(127,127,127,0.5);
 	font-weight: bold;
 	color: #292929;
+	left: 3%;
+	top: 13%;
 }
 
 .wgo-menu-item {


### PR DESCRIPTION
Small change to force the menu for the wgo board to appear in a better position. Previously this position was set at some 1000px down, which was way below the page. 