### PR TITLE
Corrected gamecount of homepage to match actual value

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -150,7 +150,7 @@ class HomePage(Page):
             quote = random.choice(Quote.objects.all())
             context['quote'] = quote
         context['discord_presence_count'] = Registry.get_discord_presence_count()
-        first_of_the_month = timezone.now().replace(day=1, hour=0, minute=0, second=0)
+        first_of_the_month = timezone.now().date().replace(day=1)
         games = Sgf.objects\
             .exclude(date__isnull=True)\
             .defer('sgf_text')\
@@ -175,7 +175,7 @@ class HomePage(Page):
         if games:
             context['games'] = games[0]
         else:
-            context['games'] = None
+            context['games'] = {"total":0}
         n_leagues = LeagueEvent.objects.filter(is_open=True, is_public=True, community__isnull=True).count()
         context['n_leagues'] = n_leagues
 #        user = request.user


### PR DESCRIPTION
This fixes the problem of having an incorrect number of games displayed on the homepage compared to the ./stats/ page for the month. 

The problem seemed to be running a date greater or equal against a datetime. The solution is to convert the datetime to a date. 

There is also a second change to fix a bug of the game counter not showing anything if no games have been played, rather than zero.

https://github.com/climu/openstudyroom/issues/412