### PR TITLE
New link for FFG hybrid ladder

### DIFF
--- a/league/go_federations.py
+++ b/league/go_federations.py
@@ -32,7 +32,8 @@ def get_ffg_ladder():
     """
     get the last FFG information
     """
-    url = "https://ffg.jeudego.org/echelle/echtxt/ech_ffg_V3.txt"
+    # url = "https://ffg.jeudego.org/echelle/echtxt/ech_ffg_V3.txt"
+    url = "https://ffg.jeudego.org/echelle/hybtxt/ech_ffg_V3.txt"
     request = requests.get(url, timeout=10)
     if request.status_code != 200:
         return None
@@ -44,7 +45,8 @@ def get_ffg_rank(ffg_licence_number):
     We return the rank (a string) or None if it's not valid
     """
     # url = "https://ffg.jeudego.org/echelle/echtxt/echelle.txt"
-    url = "https://ffg.jeudego.org/echelle/echtxt/ech_ffg_V3.txt"
+    # url = "https://ffg.jeudego.org/echelle/echtxt/ech_ffg_V3.txt"
+    url = "https://ffg.jeudego.org/echelle/hybtxt/ech_ffg_V3.txt"
     request = requests.get(url, timeout=10)
     if request.status_code == 200:
         infos = ffg_user_infos(ffg_licence_number, request.text)
@@ -66,6 +68,7 @@ def ffg_user_infos(ffg_licence_number, echelle_ffg):
     ABAD Jahin                            -3000 - 2000205 38GJ FR
     ABADIA Mickaël                        -1400 - 9728205 94MJ FR
     ABADIE Yves                           -1500 - 0452000 31To FR
+    
     """
     # we skip first line that is header
     line = None


### PR DESCRIPTION
Since May 1st 2022, online tournaments counting towards FFG ladders must now use their new hybrid ladder system : [https://ffg.jeudego.org/echelle/echelle.php](https://ffg.jeudego.org/echelle/echelle.php)

In order to write .tou files referring ranks on the correct ladder, one must use the new url provided by the FFG, as indicated in the link above. The file format seems identical, it hopefully won't cause any issue.